### PR TITLE
onChange (newValue, oldValue, keyPath)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ const cursor = Cursor.from(data, (nextValue, prevValue, keyPath) => {
 
 // Multiple update transactions are serialised.
 cursor.set('a', 2);
-// Value changed from Map { a: 1, b: 2 } to Map { a: 2, b: 2 } at []
+// Value changed from Map { a: 1, b: 2 } to Map { a: 2, b: 2 } at [ 'a' ]
 cursor.set('b', 3);
-// Value changed from Map { a: 2, b: 2 } to Map { a: 2, b: 3 } at []
+// Value changed from Map { a: 2, b: 2 } to Map { a: 2, b: 3 } at [ 'b' ]
 
 // Whilst the cursor the itself stays immutable.
 cursor.deref(); // => Map { "a": 1, "b": 2 }

--- a/README.md
+++ b/README.md
@@ -17,19 +17,18 @@ A Clojure-inspired atom is placed above the cursor composition, and is the only 
 ```js
 const data = Immutable.fromJS({a: 1, b: 2});
 
-const cursor = Cursor.from(data, (prevValue, nextValue) => {
-  console.log(newData)
-  // First call: $> Map { "a": 2, "b": 2 }
-  // Second call: $> Map { "a": 2, "b": 3 }
+const cursor = Cursor.from(data, (nextValue, prevValue, keyPath) => {
+  console.log('Value changed from', prevValue, 'to', nextValue, 'at', keyPath);
 });
 
 // Multiple update transactions are serialised.
 cursor.set('a', 2);
+// Value changed from Map { a: 1, b: 2 } to Map { a: 2, b: 2 } at []
 cursor.set('b', 3);
+// Value changed from Map { a: 2, b: 2 } to Map { a: 2, b: 3 } at []
 
 // Whilst the cursor the itself stays immutable.
-cursor.deref(); //$
-// $> Map { "a": 1, "b": 2 }
+cursor.deref(); // => Map { "a": 1, "b": 2 }
 ```
 
 This has far reaching consequences when used in component-centric view layers such as React. A typical use case

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/redbadger/immutable-cursor",
   "dependencies": {
-    "atom-store": "0.0.2",
-    "immutable": "3.7.6"
+    "atom-store": "0.0.3",
+    "immutable": "^3.7.6"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -78,14 +78,19 @@ export function subCursor(cursor, keyPath, value) {
   );
 }
 
-export function updateCursor(cursor, changeFn) {
+export function updateCursor(cursor, changeFn, keyPath) {
   const deepChange = arguments.length > 2;
   const updateFn = oldState => oldState.updateIn(
     cursor._keyPath,
     deepChange ? Map() : undefined,
     changeFn
   );
-  return makeCursor(cursor._updater(updateFn), cursor._keyPath, cursor._updater, cursor._deref);
+  return makeCursor(
+    cursor._updater(updateFn, newKeyPath(cursor._keyPath, keyPath)),
+    cursor._keyPath,
+    cursor._updater,
+    cursor._deref
+  );
 }
 
 export function wrappedValue(cursor, keyPath, value) {

--- a/test/cursor.js
+++ b/test/cursor.js
@@ -77,11 +77,11 @@ describe('Cursor', () => {
     expect(newDeepCursor.deref()).to.equal(2);
 
     expect(Immutable.is(
-      onChange.args[0][1],
+      onChange.args[0][0],
       Immutable.fromJS({a:{b:{c:2}}})
     )).to.be.true;
     expect(Immutable.is(
-      onChange.args[0][0],
+      onChange.args[0][1],
       data
     )).to.be.true;
 
@@ -89,11 +89,11 @@ describe('Cursor', () => {
     expect(newestDeepCursor.deref()).to.equal(3);
 
     expect(Immutable.is(
-      onChange.args[1][1],
+      onChange.args[1][0],
       Immutable.fromJS({a:{b:{c:3}}})
     )).to.be.true;
     expect(Immutable.is(
-      onChange.args[1][0],
+      onChange.args[1][1],
       Immutable.fromJS({a:{b:{c:2}}})
     )).to.be.true;
 
@@ -105,11 +105,11 @@ describe('Cursor', () => {
     const otherNewDeepCursor = deepCursor.update(x => x + 10);
     expect(otherNewDeepCursor.deref()).to.equal(13);
     expect(Immutable.is(
-      onChange.args[2][1],
+      onChange.args[2][0],
       Immutable.fromJS({a:{b:{c:13}}})
     )).to.be.true;
     expect(Immutable.is(
-      onChange.args[2][0],
+      onChange.args[2][1],
       data.setIn(['a', 'b', 'c'], 3) // NOT SURE IF CORRECT
     )).to.be.true;
 
@@ -144,10 +144,10 @@ describe('Cursor', () => {
 
 
     expect(Immutable.is(
-      onChange.args[0][1],
+      onChange.args[0][0],
       Immutable.fromJS({ a: { b: { c: 10 } } })
     )).to.be.true;
-    expect(Immutable.is(onChange.args[0][0], data)).to.be.true;
+    expect(Immutable.is(onChange.args[0][1], data)).to.be.true;
   });
 
   it('creates maps as necessary', () => {
@@ -186,12 +186,12 @@ describe('Cursor', () => {
     )).to.be.true;
 
     expect(Immutable.is(
-      onChange.args[0][1],
+      onChange.args[0][0],
       Immutable.fromJS({a: {b: [0, 1, 2, 3, 4]}})
     )).to.be.true;
 
     expect(Immutable.is(
-      onChange.args[0][0],
+      onChange.args[0][1],
       data
     )).to.be.true;
   });
@@ -207,12 +207,12 @@ describe('Cursor', () => {
     )).to.be.true;
 
     expect(Immutable.is(
-      onChange.args[0][1],
+      onChange.args[0][0],
       Immutable.fromJS({a: {b: [0, 1]}})
     )).to.be.true;
 
     expect(Immutable.is(
-      onChange.args[0][0],
+      onChange.args[0][1],
       data
     )).to.be.true;
   });
@@ -228,12 +228,12 @@ describe('Cursor', () => {
     )).to.be.true;
 
     expect(Immutable.is(
-      onChange.args[0][1],
+      onChange.args[0][0],
       Immutable.fromJS({a: {b: [-2, -1, 0, 1, 2]}})
     )).to.be.true;
 
     expect(Immutable.is(
-      onChange.args[0][0],
+      onChange.args[0][1],
       data
     )).to.be.true;
   });
@@ -249,12 +249,12 @@ describe('Cursor', () => {
     )).to.be.true;
 
     expect(Immutable.is(
-      onChange.args[0][1],
+      onChange.args[0][0],
       Immutable.fromJS({a: {b: [1, 2]}})
     )).to.be.true;
 
     expect(Immutable.is(
-      onChange.args[0][0],
+      onChange.args[0][1],
       data
     )).to.be.true;
   });
@@ -270,12 +270,12 @@ describe('Cursor', () => {
     found = found.set('v', 20);
 
     expect(Immutable.is(
-      onChange.args[0][1],
+      onChange.args[0][0],
       Immutable.fromJS({a: {v: 1}, b: {v: 20}, c: {v: 3}})
     )).to.be.true;
 
     expect(Immutable.is(
-      onChange.args[0][0],
+      onChange.args[0][1],
       data
     )).to.be.true;
   });
@@ -360,12 +360,12 @@ describe('Cursor', () => {
     expect(c1.getIn(['b', 'c'])).to.equal(10);
 
     expect(Immutable.is(
-      onChange.args[0][1],
+      onChange.args[0][0],
       Immutable.fromJS({a:{b:{c:10}}})
     )).to.be.true;
 
     expect(Immutable.is(
-      onChange.args[0][0],
+      onChange.args[0][1],
       data
     )).to.be.true;
   });
@@ -378,12 +378,12 @@ describe('Cursor', () => {
     expect(c1.getIn(['b', 'c'])).to.equal(10);
 
     expect(Immutable.is(
-      onChange.args[0][1],
+      onChange.args[0][0],
       Immutable.fromJS({a:{b:{c:10}}})
     )).to.be.true;
 
     expect(Immutable.is(
-      onChange.args[0][0],
+      onChange.args[0][1],
       data
     )).to.be.true;
   });
@@ -404,12 +404,12 @@ describe('Cursor', () => {
     expect(c1.deref()).to.equal(2);
 
     expect(Immutable.is(
-      onChange.args[0][1],
+      onChange.args[0][0],
       Immutable.fromJS({a:2})
     )).to.be.true;
 
     expect(Immutable.is(
-      onChange.args[0][0],
+      onChange.args[0][1],
       data
     )).to.be.true;
   });
@@ -422,12 +422,12 @@ describe('Cursor', () => {
     expect(c1.deref()).to.equal(undefined);
 
     expect(Immutable.is(
-      onChange.args[0][1],
+      onChange.args[0][0],
       Immutable.fromJS({a:undefined})
     )).to.be.true;
 
     expect(Immutable.is(
-      onChange.args[0][0],
+      onChange.args[0][1],
       data
     )).to.be.true;
   });

--- a/test/cursor.js
+++ b/test/cursor.js
@@ -431,4 +431,16 @@ describe('Cursor', () => {
       data
     )).to.be.true;
   });
+
+  it('returns update paths', () => {
+    const onChange = sinon.spy();
+    const data = Immutable.fromJS({ a: 1, b: { c: 2 } });
+    const c = Cursor.from(data, [], onChange);
+
+    c.set('a', 2);
+    c.cursor(['b', 'c']).set(3);
+
+    expect(onChange.args[0][2]).to.deep.equal(['a']);
+    expect(onChange.args[1][2]).to.deep.equal(['b', 'c']);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,9 +117,9 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-atom-store@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/atom-store/-/atom-store-0.0.2.tgz#3930e83d0e48c88d6f00aaeac4fe023da8e25d1c"
+atom-store@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/atom-store/-/atom-store-0.0.3.tgz#296566253e9f686b9225fc11ea8aa5ed2085c479"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -1519,7 +1519,7 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-immutable@3.7.6:
+immutable@^3.7.6:
   version "3.7.6"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
 


### PR DESCRIPTION
This PR mirrors the API in [contrib/cursor/index.js#L42](https://github.com/facebook/immutable-js/blob/master/contrib/cursor/index.d.ts#L42), by swapping the args in the updater callback, and adding `keyPath`.
```js
onChange?: (newValue: any, oldValue?: any, keyPath?: Array<any>) => any
```

