### PR TITLE
Remove babel-runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,3 @@
 {
-  "presets": [ "es2015", "stage-0" ],
-  "env": {
-    "test": {
-      "plugins": [ "transform-runtime" ]
-    }
-  }
+  "presets": [ "es2015", "stage-0" ]
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/redbadger/immutable-cursor",
   "dependencies": {
-    "atom-store": "0.0.3",
+    "atom-store": "^0.0.4",
     "immutable": "^3.7.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "babel-core": "^6.8.0",
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.4",
-    "babel-plugin-transform-runtime": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,9 +117,9 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-atom-store@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/atom-store/-/atom-store-0.0.3.tgz#296566253e9f686b9225fc11ea8aa5ed2085c479"
+atom-store@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/atom-store/-/atom-store-0.0.4.tgz#8bc9c1abd69f450490cdcaff0d1f09e8501ea52d"
 
 aws-sign2@~0.6.0:
   version "0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -645,12 +645,6 @@ babel-plugin-transform-regenerator@^6.22.0:
   dependencies:
     regenerator-transform "0.9.8"
 
-babel-plugin-transform-runtime@^6.8.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-transform-strict-mode@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz#e008df01340fdc87e959da65991b7e05970c8c7c"


### PR DESCRIPTION
- [x] Upgrade `atom-store@0.0.4`
- [x] Remove `babel-plugin-transform-runtime` as it's never used in the transpilation process